### PR TITLE
Fix CompileAssetsCommand timeout parameter type casting

### DIFF
--- a/src/EzPlatformEncoreBundle/bundle/Command/CompileAssetsCommand.php
+++ b/src/EzPlatformEncoreBundle/bundle/Command/CompileAssetsCommand.php
@@ -36,7 +36,7 @@ class CompileAssetsCommand extends Command
 
     protected function initialize(InputInterface $input, OutputInterface $output): void
     {
-        $timeout = $input->getOption('timeout');
+        $timeout = (float) $input->getOption('timeout');
 
         if (!is_numeric($timeout)) {
             throw new InvalidArgumentException('Timeout value has to be an integer.');
@@ -45,7 +45,7 @@ class CompileAssetsCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $timeout = $input->getOption('timeout');
+        $timeout = (float) $input->getOption('timeout');
         $env = $input->getOption('env');
 
         $output->writeln(sprintf('Compiling all <comment>%s</comment> assets.', $env));


### PR DESCRIPTION
The timeout parameter from getOption() needs to be cast to float to match the expected parameter type for Process::fromShellCommandline()

This fixes TypeError when using --timeout option with ezplatform:encore:compile command

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-XXXXX](https://jira.ez.no/browse/EZP-XXXXX)
| **Bug/Improvement**| yes/no
| **New feature**    | yes/no
| **Target version** | <!-- `1.0` for bug fixes, `master` for features -->
| **BC breaks**      | yes/no
| **Tests pass**     | yes/no
| **Doc needed**     | yes/no

<!-- Replace this comment with Pull Request description -->


**TODO**:
- [ ] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
